### PR TITLE
fixed sunssf getting set to unimplemented

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -62,7 +62,7 @@ func main() {
 }
 
 // handler gets called for any incoming sunspec request
-func handler(ctx cancel.Context, req sunspec.Request) error {
+func handler(_ cancel.Context, req sunspec.Request) error {
 	defer req.Flush()
 	for _, p := range req.Points() {
 		if p, ok := p.(sunspec.Float32); ok {

--- a/types.go
+++ b/types.go
@@ -295,7 +295,7 @@ func (t *tSunssf) decode(buf []byte) error {
 
 // set sets the point´s underlying value.
 func (t *tSunssf) set(v int16) error {
-	if v < -10 || v > 10 {
+	if v != -0x8000 && (v < -10 || v > 10) {
 		return errors.New("sunspec: value out of boundary")
 	}
 	t.data = v


### PR DESCRIPTION
Receiving the unimplemented return value from a server now properly sets the sunssf type without generating an error.
Furthermore the context parameter for the example server handler has been voided using the blank identifier since it was never used.